### PR TITLE
fix for 99 and 6 error codes

### DIFF
--- a/tor_ocr/errors.py
+++ b/tor_ocr/errors.py
@@ -5,6 +5,8 @@ class OCRError(Exception):
         2: 'parsed partially',
         3: 'ENGINE ERROR: all pages failed',
         4: 'ENGINE ERROR: FATAL',
+        6: 'Timed out while waiting for results',
+        99: 'Not a valid URL; invalid image or pdf',
     }
 
     PAGE_EXIT_CODES = {

--- a/tor_ocr/main.py
+++ b/tor_ocr/main.py
@@ -143,6 +143,10 @@ def decode_image_from_url(url, overlay=False, api_key=__OCR_API_KEY__):
             # crash and burn if the API is down, or similar :)
             result.raise_for_status()
 
+            if result.json()['OCRExitCode'] == 6:
+                # process timed out waiting for response
+                raise ConnectionError
+
             # if the request succeeds, we'll have a result. Therefore, just
             # break the loop here.
             break
@@ -165,6 +169,7 @@ def decode_image_from_url(url, overlay=False, api_key=__OCR_API_KEY__):
     return result.json()
 
 
+# noinspection PyShadowingNames
 def run(config):
     time.sleep(config.ocr_delay)
     new_post = config.redis.lpop('ocr_ids')


### PR DESCRIPTION
OCR.space brings us two new errors that are not listed in their API docs. They are:

`WARNING | run | There was an OCR Error: Unrecognized error: Code 6, ['Timed out waiting for results']: None`

`WARNING | run | There was an OCR Error: Unrecognized error: Code 99, ['Not a valid URL. URL must be of a valid and existing Image or PDF.']:`

Last night, we had approximately an hour and a half period where we received nothing but error 6, and it was heavily intermittent for hours before and after that.

This PR adds those two errors to the error class, then checks for a timeout error and treats it as a connection error to try a different server.