### PR TITLE
Bugfix for issue #29 on tor repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 We follow [Semantic Versioning](http://semver.org/) as a way of measuring stability of an update. This
 means we will never make a backwards-incompatible change within a major version of the project.
 
+## [UNRELEASED]
+
+- "Source" link in the bot footer now redirects to this repo instead of the u/tor one
+
 ## [0.2.3] -- 2021-04-05
 
 - Odd error with PRAW in https://github.com/GrafeasGroup/tor necessitates a core library upgrade

--- a/tor_ocr/core/strings.py
+++ b/tor_ocr/core/strings.py
@@ -2,7 +2,7 @@ bot_footer = (
     "{}\n\n---\n\n"
     "v{version} | This message was posted by a bot. "
     "| [FAQ](https://www.reddit.com/r/TranscribersOfReddit/wiki/index) "
-    "| [Source](https://github.com/GrafeasGroup/tor) "
+    "| [Source](https://github.com/GrafeasGroup/tor_ocr/) "
     "| Questions? [Message the mods!](https://www.reddit.com/message/"
     "compose?to=%2Fr%2FTranscribersOfReddit&subject=Bot%20Question"
     "&message=)"


### PR DESCRIPTION
The "Source" link of transcribot now redirects to this repo instead of the u/tor one.

Relevant issue: https://github.com/GrafeasGroup/tor/issues/210

## Description:

transcribot's "Source" link redirected to u/tor's repo instead of its one. This patch fixes the issue.
