### PR TITLE
Make tor_ocr wait a little longer between checks

### DIFF
--- a/tor_ocr/main.py
+++ b/tor_ocr/main.py
@@ -126,7 +126,7 @@ def noop(*args: Any) -> None:
 
 def main():
     opt = parse_arguments()
-    config.ocr_delay = 2
+    config.ocr_delay = 10
     config.debug_mode = opt.debug
     bot_name = "debug" if config.debug_mode else os.environ.get("BOT_NAME", "tor_ocr")
 


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Right now, tor_ocr checks every two seconds for new transcriptions to post. In reality, it does not need to be this high. This PR changes the timeout to 10 seconds. 

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
